### PR TITLE
Add unovis setup and TypeScript models

### DIFF
--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,9 +1,9 @@
 import { Link, Route, Routes } from 'react-router-dom'
-import { useGetPostsQuery } from './features/api/apiSlice'
+import { useGetFinanceSummaryQuery } from './features/api/apiSlice'
 import Chart from './components/Chart'
 
 function Home() {
-  const { data, isLoading } = useGetPostsQuery()
+  const { data, isLoading } = useGetFinanceSummaryQuery()
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Home</h1>

--- a/apps/ui/src/features/api/apiSlice.ts
+++ b/apps/ui/src/features/api/apiSlice.ts
@@ -1,4 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import type { Finance, FinanceSummary } from '../../types/models'
 
 export interface Post {
   id: number
@@ -17,7 +18,36 @@ export const api = createApi({
         { id: 2, title: 'Second post' },
       ],
     }),
+    getFinance: builder.query<Finance, void>({
+      query: () => '/finance',
+      // stubbed data to illustrate typing
+      transformResponse: (): Finance => ({
+        user_id: 'demo',
+        allocations: [],
+        expenses: [],
+        income_streams: [],
+        debts: [],
+        investments: [],
+        portfolios: [],
+        services: [],
+        roles: [],
+        features: [],
+        lifecycle_phase: 'stabilizing',
+        risk_profile: 'balanced',
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }),
+    }),
+    getFinanceSummary: builder.query<FinanceSummary, void>({
+      query: () => '/finance/summary',
+      transformResponse: (): FinanceSummary => ({
+        net_worth: 0,
+        investment_count: 0,
+        debt_count: 0,
+        allocation_count: 0,
+      }),
+    }),
   }),
 })
 
-export const { useGetPostsQuery } = api
+export const { useGetPostsQuery, useGetFinanceQuery, useGetFinanceSummaryQuery } = api

--- a/apps/ui/src/types/models.ts
+++ b/apps/ui/src/types/models.ts
@@ -1,0 +1,274 @@
+// Auto-generated TypeScript models mirroring the Python pydantic models in the
+// wealth backend. These interfaces enable typed communication between the UI
+// and the API.
+
+// Base entity shared across most objects
+export interface Wealth {
+  uuid: string
+  user_id: string
+  name: string
+  description?: string
+  parent_id?: string
+  tags: string[]
+  notes?: string
+  is_active: boolean
+  created_at: string
+  updated_at: string
+}
+
+// --- Risk types --------------------------------------------------------------
+export enum RiskType {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  SPECULATIVE = 'speculative',
+  GUARANTEED = 'guaranteed',
+}
+
+export enum RiskProfile {
+  CONSERVATIVE = 'conservative',
+  MODERATE = 'moderate',
+  BALANCED = 'balanced',
+  AGGRESSIVE = 'aggressive',
+  SPECULATIVE = 'speculative',
+}
+
+export interface Risk {
+  uuid: string
+  name: string
+  score: number
+  level: RiskType
+  description?: string
+  source_object_type?: string
+  source_object_id?: string
+  created_at: string
+  updated_at: string
+}
+
+// --- Service ----------------------------------------------------------------
+export interface Service {
+  uuid: string
+  name: string
+  url?: string
+  logo_url?: string
+  provider?: string
+  notes?: string
+}
+
+// --- Asset and investment models -------------------------------------------
+export enum AssetType {
+  STOCK = 'stock',
+  ETF = 'etf',
+  MUTUAL_FUND = 'mutual_fund',
+  CRYPTO = 'crypto',
+  REIT = 'reit',
+  BOND = 'bond',
+  OPTION = 'option',
+  FUTURE = 'future',
+  CASH = 'cash',
+  COMMODITY = 'commodity',
+  COLLECTIBLE = 'collectible',
+  CROWDFUNDING = 'crowdfunding',
+  ANGEL_INVESTMENT = 'angel_investment',
+  REAL_ESTATE = 'real_estate',
+  BUSINESS_EQUITY = 'business_equity',
+  OTHER = 'other',
+}
+
+export interface Investment extends Wealth {
+  asset_type: AssetType
+  amount_invested: number
+  current_value: number
+  platform?: string
+  risk_score: number
+  risk_level: RiskType
+  risk?: Risk
+}
+
+// --- Allocations -------------------------------------------------------------
+export enum AllocationType {
+  FIXED = 'fixed',
+  VARIABLE = 'variable',
+}
+
+export interface Allocation extends Wealth {
+  allocation_type: AllocationType
+  budget_amount?: number
+  budget_percentage?: number
+  savings_bucket?: string
+  risk_score: number
+  risk_level: RiskType
+  risk?: Risk
+  tags: string[]
+  services: Service[]
+  active: boolean
+}
+
+// --- Expenses ---------------------------------------------------------------
+export enum ExpenseCategory {
+  HOUSING = 'housing',
+  UTILITIES = 'utilities',
+  GROCERIES = 'groceries',
+  TRANSPORTATION = 'transportation',
+  HEALTHCARE = 'healthcare',
+  INSURANCE = 'insurance',
+  ENTERTAINMENT = 'entertainment',
+  SUBSCRIPTIONS = 'subscriptions',
+  EDUCATION = 'education',
+  CHILDCARE = 'childcare',
+  PETS = 'pets',
+  CHARITY = 'charity',
+  PERSONAL_CARE = 'personal_care',
+  GIFTS = 'gifts',
+  BUSINESS = 'business',
+  TAXES = 'taxes',
+  LOANS = 'loans',
+  DEBT_REPAYMENT = 'debt_repayment',
+  INVESTMENT = 'investment',
+  OTHER = 'other',
+}
+
+export enum ExpenseFrequency {
+  ONE_TIME = 'one_time',
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  BIWEEKLY = 'biweekly',
+  SEMIMONTHLY = 'semimonthly',
+  MONTHLY = 'monthly',
+  BIMONTHLY = 'bimonthly',
+  QUARTERLY = 'quarterly',
+  SEMIANNUALLY = 'semiannually',
+  ANNUALLY = 'annually',
+  IRREGULAR = 'irregular',
+}
+
+export interface Expense extends Wealth {
+  amount: number
+  date: string
+  category: ExpenseCategory
+  frequency: ExpenseFrequency
+  source_account: string
+}
+
+// --- Income -----------------------------------------------------------------
+export enum IncomeType {
+  ACTIVE = 'active',
+  PASSIVE = 'passive',
+  FREELANCE = 'freelance',
+  BUSINESS = 'business',
+  INVESTMENT = 'investment',
+  RENTAL = 'rental',
+  PLATFORM = 'platform',
+  CRYPTO = 'crypto',
+  ROYALTY = 'royalty',
+  RETIREMENT = 'retirement',
+  SOCIAL_SECURITY = 'social_security',
+  STIPEND = 'stipend',
+  DISABILITY = 'disability',
+  CHILD_SUPPORT = 'child_support',
+  ALIMONY = 'alimony',
+  WINDFALL = 'windfall',
+  OTHER = 'other',
+}
+
+export enum IncomeFrequency {
+  ONE_TIME = 'one_time',
+  DAILY = 'daily',
+  WEEKLY = 'weekly',
+  BIWEEKLY = 'biweekly',
+  SEMIMONTHLY = 'semimonthly',
+  MONTHLY = 'monthly',
+  BIMONTHLY = 'bimonthly',
+  QUARTERLY = 'quarterly',
+  SEMIANNUALLY = 'semiannually',
+  ANNUALLY = 'annually',
+  IRREGULAR = 'irregular',
+}
+
+export interface Income extends Wealth {
+  source: string
+  amount: number
+  frequency: IncomeFrequency
+  type: IncomeType
+}
+
+// --- Debts ------------------------------------------------------------------
+export enum DebtType {
+  CREDIT_CARD = 'credit_card',
+  PERSONAL_LOAN = 'personal_loan',
+  STUDENT_LOAN = 'student_loan',
+  AUTO_LOAN = 'auto_loan',
+  MORTGAGE = 'mortgage',
+  MEDICAL = 'medical',
+  BUSINESS_LOAN = 'business_loan',
+  LINE_OF_CREDIT = 'line_of_credit',
+  BUY_NOW_PAY_LATER = 'buy_now_pay_later',
+  OTHER = 'other',
+}
+
+export enum DebtStatus {
+  OPEN = 'open',
+  CLOSED = 'closed',
+  DEFAULTED = 'defaulted',
+  DEFERRED = 'deferred',
+  PAID_OFF = 'paid_off',
+}
+
+export interface Debt extends Wealth {
+  debt_type: DebtType
+  status: DebtStatus
+  balance: number
+  apr: number
+  min_payment: number
+  snowball_priority?: number
+  risk_score: number
+  risk_level: RiskType
+  risk?: Risk
+  lender?: string
+  account_number?: string
+  due_day?: number
+  is_tax_deductible: boolean
+  auto_pay_enabled: boolean
+}
+
+// --- Portfolio --------------------------------------------------------------
+export interface Portfolio extends Wealth {
+  investments: Investment[]
+  risk_profile?: RiskProfile
+  strategy_label?: string
+}
+
+// --- Finance ----------------------------------------------------------------
+export interface Finance {
+  user_id: string
+  allocations: Allocation[]
+  expenses: Expense[]
+  income_streams: Income[]
+  debts: Debt[]
+  investments: Investment[]
+  portfolios: Portfolio[]
+  services: Service[]
+  roles: string[]
+  features: string[]
+  lifecycle_phase: LifecyclePhase
+  risk_profile?: RiskProfile
+  notes?: string
+  created_at: string
+  updated_at: string
+}
+
+export interface FinanceSummary {
+  net_worth: number
+  investment_count: number
+  debt_count: number
+  allocation_count: number
+}
+
+export enum LifecyclePhase {
+  SURVIVING = 'surviving',
+  STABILIZING = 'stabilizing',
+  MAINTAINING = 'maintaining',
+  SCALING = 'scaling',
+  THRIVING = 'thriving',
+  RETIRING = 'retiring',
+}


### PR DESCRIPTION
## Summary
- add comprehensive TypeScript interfaces mirroring the Python models
- expose new finance endpoints in the api slice
- display finance summary on the home page

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*
- `npx tsc --noEmit` *(fails: missing dependencies)*
