### PR TITLE
Add common Vite plugins

### DIFF
--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -7,6 +7,11 @@ This is a React application bootstrapped with Vite and TypeScript. It uses pnpm 
 - Redux Toolkit with RTK Query
 - Keycloak and Google authentication stubs
 - Unovis for charting
+- Vite dev server proxy to the FastAPI backend
+- Path aliases via `vite-tsconfig-paths`
+- Type checking with `vite-plugin-checker`
+- SVG imports with `vite-plugin-svgr`
+- Optional PWA support via `vite-plugin-pwa`
 
 ## Getting Started
 

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -26,6 +26,10 @@
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
     "vite": "^5.2.2",
-    "@vitejs/plugin-react": "^4.2.0"
+    "@vitejs/plugin-react-swc": "^4.2.0",
+    "vite-tsconfig-paths": "^4.2.0",
+    "vite-plugin-checker": "^1.0.0",
+    "vite-plugin-svgr": "^3.0.0",
+    "vite-plugin-pwa": "^0.16.0"
   }
 }

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,9 +1,25 @@
 import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import react from '@vitejs/plugin-react-swc'
+import tsconfigPaths from 'vite-tsconfig-paths'
+import checker from 'vite-plugin-checker'
+import svgr from 'vite-plugin-svgr'
+import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    tsconfigPaths(),
+    checker({ typescript: true, eslint: { files: ['./src'] } }),
+    svgr(),
+    VitePWA(),
+  ],
   server: {
     port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- set up a more complete Vite config with common plugins
- switch to the React SWC plugin and document the new tools

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wealth')*