### PR TITLE
Integrate Keycloak into React app

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.3",
+    "@react-keycloak/web": "^4.0.2",
     "keycloak-js": "^23.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -1,12 +1,16 @@
-import { Link, Route, Routes } from 'react-router-dom'
+import { Route, Routes } from 'react-router-dom'
 import { useGetFinanceSummaryQuery } from './features/api/apiSlice'
 import Chart from './components/Chart'
+import AuthStatus from './components/AuthStatus'
 
 function Home() {
   const { data, isLoading } = useGetFinanceSummaryQuery()
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Home</h1>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Home</h1>
+        <AuthStatus />
+      </div>
       {isLoading ? 'Loading...' : <pre>{JSON.stringify(data, null, 2)}</pre>}
       <Chart />
     </div>

--- a/apps/ui/src/components/AuthStatus.tsx
+++ b/apps/ui/src/components/AuthStatus.tsx
@@ -1,0 +1,32 @@
+import { useKeycloak } from '@react-keycloak/web'
+
+export default function AuthStatus() {
+  const { keycloak } = useKeycloak()
+
+  if (keycloak.authenticated) {
+    const roles = (keycloak.tokenParsed as any)?.realm_access?.roles || []
+    return (
+      <div className="flex gap-2 items-center">
+        <span className="font-semibold">
+          {keycloak.tokenParsed?.preferred_username}
+        </span>
+        {roles.length > 0 && <span>Roles: {roles.join(', ')}</span>}
+        <button
+          className="px-2 py-1 bg-gray-200 rounded"
+          onClick={() => keycloak.logout()}
+        >
+          Logout
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      className="px-2 py-1 bg-gray-200 rounded"
+      onClick={() => keycloak.login()}
+    >
+      Login
+    </button>
+  )
+}

--- a/apps/ui/src/main.tsx
+++ b/apps/ui/src/main.tsx
@@ -2,16 +2,20 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { BrowserRouter } from 'react-router-dom'
+import { ReactKeycloakProvider } from '@react-keycloak/web'
 import App from './App'
 import { store } from './store'
+import keycloak from './keycloak'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <Provider store={store}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
+      <ReactKeycloakProvider authClient={keycloak}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ReactKeycloakProvider>
     </Provider>
   </React.StrictMode>
 )


### PR DESCRIPTION
## Summary
- add `@react-keycloak/web` dependency
- add `AuthStatus` component for login state
- wrap app in `ReactKeycloakProvider`
- show login info and roles in Home page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*