### PR TITLE
Add environment-based configuration for React UI

### DIFF
--- a/.env
+++ b/.env
@@ -20,3 +20,9 @@ KEYCLOAK_DB_USER=keycloak
 KEYCLOAK_DB_PASSWORD=keycloakpass
 KEYCLOAK_DB_NAME=keycloak
 
+# UI runtime configuration
+VITE_API_BASE_URL=http://localhost:8000
+VITE_KEYCLOAK_URL=http://localhost:8080
+VITE_KEYCLOAK_REALM=wealth
+VITE_KEYCLOAK_CLIENT_ID=frontend
+

--- a/.env.demo
+++ b/.env.demo
@@ -20,3 +20,9 @@ KEYCLOAK_DB_USER=keycloak
 KEYCLOAK_DB_PASSWORD=keycloakpass
 KEYCLOAK_DB_NAME=keycloak
 
+# UI runtime configuration
+VITE_API_BASE_URL=http://localhost:8000
+VITE_KEYCLOAK_URL=http://localhost:8080
+VITE_KEYCLOAK_REALM=wealth
+VITE_KEYCLOAK_CLIENT_ID=frontend
+

--- a/.env.development
+++ b/.env.development
@@ -20,3 +20,9 @@ KEYCLOAK_DB_USER=keycloak
 KEYCLOAK_DB_PASSWORD=keycloakpass
 KEYCLOAK_DB_NAME=keycloak
 
+# UI runtime configuration
+VITE_API_BASE_URL=http://localhost:8000
+VITE_KEYCLOAK_URL=http://localhost:8080
+VITE_KEYCLOAK_REALM=wealth
+VITE_KEYCLOAK_CLIENT_ID=frontend
+

--- a/.env.production
+++ b/.env.production
@@ -20,3 +20,9 @@ KEYCLOAK_DB_USER=keycloak
 KEYCLOAK_DB_PASSWORD=keycloakpass
 KEYCLOAK_DB_NAME=keycloak
 
+# UI runtime configuration
+VITE_API_BASE_URL=http://localhost:8000
+VITE_KEYCLOAK_URL=http://localhost:8080
+VITE_KEYCLOAK_REALM=wealth
+VITE_KEYCLOAK_CLIENT_ID=frontend
+

--- a/.env.staging
+++ b/.env.staging
@@ -20,3 +20,9 @@ KEYCLOAK_DB_USER=keycloak
 KEYCLOAK_DB_PASSWORD=keycloakpass
 KEYCLOAK_DB_NAME=keycloak
 
+# UI runtime configuration
+VITE_API_BASE_URL=http://localhost:8000
+VITE_KEYCLOAK_URL=http://localhost:8080
+VITE_KEYCLOAK_REALM=wealth
+VITE_KEYCLOAK_CLIENT_ID=frontend
+

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Run the development server:
 pnpm dev
 ```
 
+The UI relies on `VITE_API_BASE_URL` and related variables to know where the API
+and authentication services live. These values are read from the `.env.*` files
+used by Docker Compose so each environment automatically points to the correct
+services.
+
 ### Docker Compose
 
 Several compose files make it easy to run the API and UI in different environments. The base configuration lives in `docker-compose.base.yml`, with environment-specific overrides for development, staging, demo and production.

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -13,4 +13,4 @@ RUN pnpm install
 COPY . .
 
 EXPOSE 5173
-CMD ["pnpm", "dev", "--host"]
+CMD ["sh", "-c", "pnpm dev --host --port ${UI_PORT:-5173}"]

--- a/apps/ui/README.md
+++ b/apps/ui/README.md
@@ -33,4 +33,17 @@ Build for production:
 pnpm build
 ```
 
+### Configuration
+
+Runtime options are provided via environment variables. Set them in a `.env`
+file or pass them through your container runtime.
+
+- `VITE_API_BASE_URL` - base URL for the API service
+- `VITE_KEYCLOAK_URL` - Keycloak server URL
+- `VITE_KEYCLOAK_REALM` - authentication realm
+- `VITE_KEYCLOAK_CLIENT_ID` - Keycloak client id
+
+The Docker Compose setups load these variables from their respective `.env.*`
+files so the UI automatically points at the correct services.
+
 

--- a/apps/ui/src/App.tsx
+++ b/apps/ui/src/App.tsx
@@ -4,14 +4,20 @@ import Chart from './components/Chart'
 import AuthStatus from './components/AuthStatus'
 
 function Home() {
-  const { data, isLoading } = useGetFinanceSummaryQuery()
+  const { data, isLoading, isError, error } = useGetFinanceSummaryQuery()
   return (
     <div className="p-4">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Home</h1>
         <AuthStatus />
       </div>
-      {isLoading ? 'Loading...' : <pre>{JSON.stringify(data, null, 2)}</pre>}
+      {isLoading && 'Loading...'}
+      {isError && (
+        <div className="text-red-500">Error: {String(error)}</div>
+      )}
+      {!isLoading && !isError && (
+        <pre>{JSON.stringify(data, null, 2)}</pre>
+      )}
       <Chart />
     </div>
   )

--- a/apps/ui/src/config.ts
+++ b/apps/ui/src/config.ts
@@ -1,0 +1,4 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api'
+export const KEYCLOAK_URL = import.meta.env.VITE_KEYCLOAK_URL || 'http://localhost:8080'
+export const KEYCLOAK_REALM = import.meta.env.VITE_KEYCLOAK_REALM || 'wealth'
+export const KEYCLOAK_CLIENT_ID = import.meta.env.VITE_KEYCLOAK_CLIENT_ID || 'frontend'

--- a/apps/ui/src/features/api/apiSlice.ts
+++ b/apps/ui/src/features/api/apiSlice.ts
@@ -1,5 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
 import type { Finance, FinanceSummary } from '../../types/models'
+import { API_BASE_URL } from '../../config'
 
 export interface Post {
   id: number
@@ -8,7 +9,7 @@ export interface Post {
 
 export const api = createApi({
   reducerPath: 'api',
-  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
+  baseQuery: fetchBaseQuery({ baseUrl: API_BASE_URL }),
   endpoints: builder => ({
     getPosts: builder.query<Post[], void>({
       query: () => '/posts',

--- a/apps/ui/src/keycloak.ts
+++ b/apps/ui/src/keycloak.ts
@@ -1,9 +1,10 @@
 import Keycloak from 'keycloak-js'
+import { KEYCLOAK_URL, KEYCLOAK_REALM, KEYCLOAK_CLIENT_ID } from './config'
 
 const keycloak = new Keycloak({
-  url: 'http://localhost:8080',
-  realm: 'wealth',
-  clientId: 'frontend',
+  url: KEYCLOAK_URL,
+  realm: KEYCLOAK_REALM,
+  clientId: KEYCLOAK_CLIENT_ID,
 })
 
 export default keycloak

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
     VitePWA(),
   ],
   server: {
-    port: 5173,
+    port: Number(process.env.UI_PORT) || 5173,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: `http://localhost:${process.env.API_PORT || 8000}`,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- configure React app via `.env` variables
- expose new config helper and wire Keycloak/API to it
- improve error handling in `Home` component
- allow Vite dev server port to come from env vars
- document the new variables

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wealth')*