### PR TITLE
Introduce Pydantic-based Config for API

### DIFF
--- a/services/api/config.py
+++ b/services/api/config.py
@@ -1,0 +1,40 @@
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Config(BaseSettings):
+    """Application configuration loaded from environment."""
+
+    db_host: str = Field("localhost", env="API_DB_HOST")
+    db_port: int = Field(5432, env="API_DB_PORT")
+    db_user: str = Field("wealth", env="API_DB_USER")
+    db_password: str = Field("wealthpass", env="API_DB_PASSWORD")
+    db_name: str = Field("wealth", env="API_DB_NAME")
+
+    google_client_id: str = Field("CHANGE_ME", env="GOOGLE_CLIENT_ID")
+    google_client_secret: str = Field("CHANGE_ME", env="GOOGLE_CLIENT_SECRET")
+
+    keycloak_server_url: str = Field(
+        "http://localhost:8080/auth/", env="KEYCLOAK_SERVER_URL"
+    )
+    keycloak_client_id: str = Field("wealth-api", env="KEYCLOAK_CLIENT_ID")
+    keycloak_client_secret: str = Field(
+        "CHANGE_ME", env="KEYCLOAK_CLIENT_SECRET"
+    )
+    keycloak_admin_client_secret: str = Field(
+        "CHANGE_ME", env="KEYCLOAK_ADMIN_CLIENT_SECRET"
+    )
+    keycloak_realm: str = Field("wealth", env="KEYCLOAK_REALM")
+    keycloak_redirect_uri: str = Field(
+        "http://localhost:8000/callback", env="KEYCLOAK_REDIRECT_URI"
+    )
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+@lru_cache()
+def get_config() -> Config:
+    """Return a cached Config instance."""
+    return Config()

--- a/services/api/main.py
+++ b/services/api/main.py
@@ -3,30 +3,28 @@ from pydantic import BaseModel
 import asyncpg
 from fastapi_keycloak import FastAPIKeycloak, OIDCUser
 from authlib.integrations.starlette_client import OAuth
-import os
+
+from .config import get_config
 
 app = FastAPI(title="Wealth API")
 
-# Database configuration from environment
-DB_HOST = os.getenv("API_DB_HOST", "localhost")
-DB_PORT = os.getenv("API_DB_PORT", "5432")
-DB_USER = os.getenv("API_DB_USER", "wealth")
-DB_PASSWORD = os.getenv("API_DB_PASSWORD", "wealthpass")
-DB_NAME = os.getenv("API_DB_NAME", "wealth")
+config = get_config()
+
 DATABASE_URL = (
-    f"postgresql://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+    f"postgresql://{config.db_user}:{config.db_password}@"
+    f"{config.db_host}:{config.db_port}/{config.db_name}"
 )
 
 db_pool: asyncpg.Pool | None = None
 
 # Configure Keycloak connection. Adjust URLs and secrets for your environment.
 keycloak = FastAPIKeycloak(
-    server_url="http://localhost:8080/auth/",
-    client_id="wealth-api",
-    client_secret="CHANGE_ME",
-    admin_client_secret="CHANGE_ME",
-    realm="wealth",
-    redirect_uri="http://localhost:8000/callback",
+    server_url=config.keycloak_server_url,
+    client_id=config.keycloak_client_id,
+    client_secret=config.keycloak_client_secret,
+    admin_client_secret=config.keycloak_admin_client_secret,
+    realm=config.keycloak_realm,
+    redirect_uri=config.keycloak_redirect_uri,
 )
 
 # Configure Google OAuth2
@@ -34,8 +32,8 @@ oauth = OAuth()
 oauth.register(
     name="google",
     server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
-    client_id=os.getenv("GOOGLE_CLIENT_ID", "CHANGE_ME"),
-    client_secret=os.getenv("GOOGLE_CLIENT_SECRET", "CHANGE_ME"),
+    client_id=config.google_client_id,
+    client_secret=config.google_client_secret,
     client_kwargs={"scope": "openid email profile"},
 )
 


### PR DESCRIPTION
## Summary
- centralize API configuration with a `Config` class based on `pydantic_settings`
- use the new config in API service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wealth')*