### PR TITLE
Setup Alembic and message model

### DIFF
--- a/services/api/alembic.ini
+++ b/services/api/alembic.ini
@@ -1,0 +1,27 @@
+[alembic]
+script_location = services/api/alembic
+sqlalchemy.url =
+
+defaults.generic_poolclass = NullPool
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/services/api/alembic/env.py
+++ b/services/api/alembic/env.py
@@ -1,0 +1,45 @@
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import pool
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from services.api.models import Base
+from services.api.database import get_database_url
+
+config = context.config
+fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = get_database_url()
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True, dialect_opts={"paramstyle": "named"})
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    connectable = create_async_engine(get_database_url(), poolclass=pool.NullPool)
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/services/api/alembic/versions/0001_create_messages_table.py
+++ b/services/api/alembic/versions/0001_create_messages_table.py
@@ -1,0 +1,28 @@
+"""create messages table"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_create_messages_table"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("message", sa.Text(), nullable=False, server_default="Hello World"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("messages")

--- a/services/api/database.py
+++ b/services/api/database.py
@@ -1,0 +1,22 @@
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
+
+from .config import get_config
+from .models import Base
+
+
+def get_database_url() -> str:
+    cfg = get_config()
+    return (
+        f"postgresql+asyncpg://{cfg.db_user}:{cfg.db_password}@"
+        f"{cfg.db_host}:{cfg.db_port}/{cfg.db_name}"
+    )
+
+
+engine = create_async_engine(get_database_url(), future=True, echo=False)
+
+async_session = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_session() -> AsyncSession:
+    async with async_session() as session:
+        yield session

--- a/services/api/migrations.py
+++ b/services/api/migrations.py
@@ -1,0 +1,17 @@
+import asyncio
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+from .database import get_database_url
+
+
+def run_migrations() -> None:
+    alembic_cfg = Config(str(Path(__file__).with_name("alembic.ini")))
+    alembic_cfg.set_main_option("sqlalchemy.url", get_database_url())
+    command.upgrade(alembic_cfg, "head")
+
+
+async def run_migrations_async() -> None:
+    await asyncio.to_thread(run_migrations)

--- a/services/api/models/__init__.py
+++ b/services/api/models/__init__.py
@@ -1,0 +1,4 @@
+from .base import Base
+from .message import Message
+
+__all__ = ["Base", "Message"]

--- a/services/api/models/base.py
+++ b/services/api/models/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/services/api/models/message.py
+++ b/services/api/models/message.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, Text, DateTime, func
+
+from .base import Base
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id = Column(Integer, primary_key=True)
+    message = Column(Text, nullable=False, server_default="Hello World")
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/services/api/schemas/__init__.py
+++ b/services/api/schemas/__init__.py
@@ -1,0 +1,3 @@
+from .message import MessageCreate, MessageRead
+
+__all__ = ["MessageCreate", "MessageRead"]

--- a/services/api/schemas/message.py
+++ b/services/api/schemas/message.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class MessageCreate(BaseModel):
+    message: str = "Hello World"
+
+
+class MessageRead(MessageCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True

--- a/wealth/pyproject.toml
+++ b/wealth/pyproject.toml
@@ -24,6 +24,8 @@ uvicorn = "^0.30.0"
 fastapi-keycloak = "^0.7.0"
 authlib = "^1.3.0"
 asyncpg = "^0.29.0"
+SQLAlchemy = "^2.0"
+alembic = "^1.13.1"
 
 [tool.poetry.scripts]
 wealth = "wealth.cli:cli"


### PR DESCRIPTION
## Summary
- add SQLAlchemy and Alembic dependencies
- create standalone Message model and schemas
- move DB setup to separate modules
- initialize Alembic with first migration
- refactor FastAPI app to use SQLAlchemy models and migrations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*
