### PR TITLE
Fix migrations for user table

### DIFF
--- a/services/api/alembic/versions/0001_create_messages_table.py
+++ b/services/api/alembic/versions/0001_create_messages_table.py
@@ -1,4 +1,4 @@
-"""create messages table"""
+"""create users and messages tables"""
 
 from alembic import op
 import sqlalchemy as sa
@@ -11,8 +11,16 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
+        "users",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("preferred_username", sa.String(), nullable=True),
+        sa.Column("email", sa.String(), nullable=True),
+    )
+
+    op.create_table(
         "messages",
         sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
         sa.Column("message", sa.Text(), nullable=False, server_default="Hello World"),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
         sa.Column(
@@ -26,3 +34,4 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("messages")
+    op.drop_table("users")

--- a/services/api/alembic/versions/0002_create_map_states_table.py
+++ b/services/api/alembic/versions/0002_create_map_states_table.py
@@ -1,4 +1,4 @@
-"""create users and map_states tables"""
+"""create map_states table"""
 
 from alembic import op
 import sqlalchemy as sa
@@ -10,16 +10,6 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "users",
-        sa.Column("id", sa.String(), primary_key=True),
-        sa.Column("preferred_username", sa.String(), nullable=True),
-        sa.Column("email", sa.String(), nullable=True),
-    )
-
-    op.add_column("messages", sa.Column("user_id", sa.String(), nullable=False))
-    op.create_foreign_key(None, "messages", "users", ["user_id"], ["id"])
-
     op.create_table(
         "map_states",
         sa.Column("id", sa.Integer(), primary_key=True),
@@ -43,6 +33,3 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_table("map_states")
-    op.drop_constraint(None, "messages", type_="foreignkey")
-    op.drop_column("messages", "user_id")
-    op.drop_table("users")


### PR DESCRIPTION
## Summary
- add users table to initial Alembic migration
- adjust second migration to only handle map states

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'wealth')*