### PR TITLE
Centralize table names and revisions

### DIFF
--- a/services/api/alembic/versions/0001_create_messages_table.py
+++ b/services/api/alembic/versions/0001_create_messages_table.py
@@ -3,7 +3,13 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0001_create_messages_table"
+from services.api.constants import (
+    MESSAGES_TABLE,
+    USERS_TABLE,
+    REVISION_CREATE_MESSAGES_TABLE,
+)
+
+revision = REVISION_CREATE_MESSAGES_TABLE
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -11,16 +17,16 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        "users",
+        USERS_TABLE,
         sa.Column("id", sa.String(), primary_key=True),
         sa.Column("preferred_username", sa.String(), nullable=True),
         sa.Column("email", sa.String(), nullable=True),
     )
 
     op.create_table(
-        "messages",
+        MESSAGES_TABLE,
         sa.Column("id", sa.Integer, primary_key=True),
-        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("user_id", sa.String(), sa.ForeignKey(f"{USERS_TABLE}.id"), nullable=False),
         sa.Column("message", sa.Text(), nullable=False, server_default="Hello World"),
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
         sa.Column(
@@ -33,5 +39,5 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("messages")
-    op.drop_table("users")
+    op.drop_table(MESSAGES_TABLE)
+    op.drop_table(USERS_TABLE)

--- a/services/api/alembic/versions/0002_create_map_states_table.py
+++ b/services/api/alembic/versions/0002_create_map_states_table.py
@@ -3,17 +3,24 @@
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0002_create_map_states_table"
-down_revision = "0001_create_messages_table"
+from services.api.constants import (
+    MAP_STATES_TABLE,
+    USERS_TABLE,
+    REVISION_CREATE_MAP_STATES_TABLE,
+    REVISION_CREATE_MESSAGES_TABLE,
+)
+
+revision = REVISION_CREATE_MAP_STATES_TABLE
+down_revision = REVISION_CREATE_MESSAGES_TABLE
 branch_labels = None
 depends_on = None
 
 
 def upgrade() -> None:
     op.create_table(
-        "map_states",
+        MAP_STATES_TABLE,
         sa.Column("id", sa.Integer(), primary_key=True),
-        sa.Column("user_id", sa.String(), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("user_id", sa.String(), sa.ForeignKey(f"{USERS_TABLE}.id"), nullable=False),
         sa.Column("state", sa.JSON(), nullable=False),
         sa.Column(
             "created_at",
@@ -32,4 +39,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_table("map_states")
+    op.drop_table(MAP_STATES_TABLE)

--- a/services/api/constants.py
+++ b/services/api/constants.py
@@ -1,0 +1,8 @@
+# Constants for database table names and Alembic revision identifiers
+
+USERS_TABLE = "users"
+MESSAGES_TABLE = "messages"
+MAP_STATES_TABLE = "map_states"
+
+REVISION_CREATE_MESSAGES_TABLE = "0001_create_messages_table"
+REVISION_CREATE_MAP_STATES_TABLE = "0002_create_map_states_table"

--- a/services/api/models/map_state.py
+++ b/services/api/models/map_state.py
@@ -1,14 +1,16 @@
 from sqlalchemy import Column, Integer, DateTime, func, String, ForeignKey, JSON
 from sqlalchemy.orm import relationship
 
+from services.api.constants import MAP_STATES_TABLE, USERS_TABLE
+
 from .base import Base
 
 
 class MapState(Base):
-    __tablename__ = "map_states"
+    __tablename__ = MAP_STATES_TABLE
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user_id = Column(String, ForeignKey(f"{USERS_TABLE}.id"), nullable=False)
     state = Column(JSON, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(

--- a/services/api/models/message.py
+++ b/services/api/models/message.py
@@ -1,14 +1,16 @@
 from sqlalchemy import Column, Integer, Text, DateTime, func, String, ForeignKey
 from sqlalchemy.orm import relationship
 
+from services.api.constants import MESSAGES_TABLE, USERS_TABLE
+
 from .base import Base
 
 
 class Message(Base):
-    __tablename__ = "messages"
+    __tablename__ = MESSAGES_TABLE
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(String, ForeignKey("users.id"), nullable=False)
+    user_id = Column(String, ForeignKey(f"{USERS_TABLE}.id"), nullable=False)
     message = Column(Text, nullable=False, server_default="Hello World")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(

--- a/services/api/models/user.py
+++ b/services/api/models/user.py
@@ -1,11 +1,13 @@
 from sqlalchemy import Column, String
 from sqlalchemy.orm import relationship
 
+from services.api.constants import USERS_TABLE
+
 from .base import Base
 
 
 class User(Base):
-    __tablename__ = "users"
+    __tablename__ = USERS_TABLE
 
     id = Column(String, primary_key=True)
     preferred_username = Column(String, nullable=True)


### PR DESCRIPTION
## Summary
- define constants for database table names and alembic revision strings
- use those constants in ORM models
- use the constants in alembic migration scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*