### PR TITLE
Add nix support for devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,13 +25,12 @@
     "ghcr.io/devcontainers/features/nix:1": {
       "version": "latest",
       "multiUser": true,
-      "packages": "",
+      "packages": "nodejs_20 pnpm python312Full poetry git",
       "useAttributePath": true,
-      "flakeUri": "",
-      "extraNixConfig": ""
+      "extraNixConfig": "experimental-features = nix-command flakes"
     }
   },
-  "postCreateCommand": "python3 /workspace/.devcontainer/post_create.py",
+  "postCreateCommand": "python3 /workspace/.devcontainer/post_create.py && nix develop /workspace --command true",
   "mounts": [
     "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind",
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"

--- a/.gitignore
+++ b/.gitignore
@@ -122,4 +122,8 @@ node_modules/
 apps/ui/node_modules/
 apps/ui/dist/
 
+# Nix build artifacts
+result
+.direnv/
+
 .mega-linter-reports/

--- a/README.md
+++ b/README.md
@@ -103,3 +103,16 @@ To automatically fix problems run:
 task lint:fix
 ```
 
+## Nix development environment
+
+The repository includes a small `flake.nix` describing the tooling used in
+development. If you have [Nix](https://nixos.org/) installed you can enter a
+shell with all required packages using:
+
+```bash
+nix develop
+```
+
+The dev container is configured to install Nix and use this flake, providing a
+consistent setup across machines.
+

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Wealth development shell";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+
+  outputs = { self, nixpkgs }: let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs { inherit system; };
+  in {
+    devShells.${system}.default = pkgs.mkShell {
+      packages = [
+        pkgs.nodejs_20
+        pkgs.pnpm
+        pkgs.python312Full
+        pkgs.poetry
+        pkgs.git
+      ];
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add a flake with Node, pnpm and Python tooling
- ignore nix output directories
- configure devcontainer to install nix packages
- warm nix shell on creation
- document using `nix develop`

## Testing
- `PYTHONPATH=wealth pytest -q wealth/tests` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_683ac0470264832cb7817e057484c062