### PR TITLE
Setup pre-commit and update linting

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
         "ghcr.io/devcontainers/features/nix:1": {
             "version": "latest",
             "multiUser": true,
-            "packages": "nodejs_20 pnpm python312Full poetry git",
+        "packages": "nodejs_20 pnpm python312Full poetry git pre-commit black nodePackages.prettier",
             "useAttributePath": true,
             "extraNixConfig": "experimental-features = nix-command flakes"
         },
@@ -31,7 +31,7 @@
         },
         "./features/docker-proxy": {}
     },
-    "postCreateCommand": "python3 /usr/local/share/docker-proxy-setup.py && nix develop /workspace --command true",
+    "postCreateCommand": "python3 /usr/local/share/docker-proxy-setup.py && nix develop /workspace --command pre-commit install",
     "mounts": [
         "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind",
         "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,7 +2,9 @@ name: MegaLinter
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - develop
   pull_request:
 
 jobs:
@@ -10,7 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: MegaLinter
-        uses: oxsecurity/megalinter@v7
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Run MegaLinter
+        run: npx mega-linter-runner --install-tools
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.2.5
+    hooks:
+      - id: prettier
+        additional_dependencies: ["prettier@3.2.5"]

--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ The dev container is configured to install Nix and use this flake, providing a
 consistent setup across machines. The devtools feature installs MegaLinter so
 you can run `task lint` directly inside the container.
 
+## Pre-commit hooks
+
+Fast checks run automatically via [pre-commit](https://pre-commit.com/). The dev
+container installs the tool and runs `pre-commit install` for you. If working
+outside the container make sure `pre-commit` is available and run:
+
+```bash
+pre-commit install
+```
+
+Hooks like Black and Prettier will then execute before each commit.
+
 ## Commit messages
 
 This repository uses [commitlint](https://commitlint.js.org/) to enforce the

--- a/flake.nix
+++ b/flake.nix
@@ -13,14 +13,17 @@
           inherit system;
         };
       in {
-        devShells.default = pkgs.mkShell {
-          buildInputs = [
-            pkgs.nodejs_20
-            pkgs.pnpm
-            pkgs.python312Full
-            pkgs.poetry
-            pkgs.git
-          ];
+          devShells.default = pkgs.mkShell {
+            buildInputs = [
+              pkgs.nodejs_20
+              pkgs.pnpm
+              pkgs.python312Full
+              pkgs.poetry
+              pkgs.git
+              pkgs.pre-commit
+              pkgs.black
+              pkgs.nodePackages.prettier
+            ];
 
           shellHook = ''
             echo "✅ dev shell ready (Node, Python, Poetry, PNPM)"


### PR DESCRIPTION
## Summary
- add pre-commit config
- install pre-commit, black and prettier in devcontainer
- auto-install hooks when container starts
- extend nix dev shell with lint tools
- harden MegaLinter workflow
- document pre-commit usage

## Testing
- `pre-commit --version` *(fails: command not found)*
- `npx mega-linter-runner --version` *(fails: npm 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f96856014832c8c57a95cdfc89f92