### PR TITLE
Add schema integration and SQLModel support

### DIFF
--- a/wealth/pyproject.toml
+++ b/wealth/pyproject.toml
@@ -10,6 +10,7 @@ authors = ["Alan Szmyt <szmyty@gmail.com>"]
 license = "MIT"
 readme = "README.md"
 packages = [{ include = "wealth" }]
+include = [{ path = "wealth/schemas/wealth.schema.json" }]
 
 [tool.poetry.dependencies]
 python = "^3.12"
@@ -29,6 +30,8 @@ alembic = "^1.13.1"
 structlog = "^24.1.0"
 python-json-logger = "^2.0.7"
 loguru = "^0.7.2"
+sqlmodel = "^0.0.14"
+jsonschema = "^4.21.1"
 
 [tool.poetry.scripts]
 wealth = "wealth.cli:cli"

--- a/wealth/tests/test_schema.py
+++ b/wealth/tests/test_schema.py
@@ -1,0 +1,11 @@
+from wealth.schemas import load_schema, validate_finance
+from wealth.mock import generate_mock_finance
+
+
+def test_load_schema():
+    schema = load_schema()
+    assert "definitions" in schema
+
+
+def test_validate_finance(mock_finance):
+    validate_finance(mock_finance)

--- a/wealth/tests/test_sqlmodels.py
+++ b/wealth/tests/test_sqlmodels.py
@@ -1,0 +1,21 @@
+from sqlmodel import create_engine, Session, select
+from wealth.db import AllocationModel, InvestmentModel, create_db_and_tables
+from wealth.mock import generate_mock_finance
+
+
+def test_allocation_sqlmodel_roundtrip():
+    finance = generate_mock_finance("sqlmodel-user")
+    alloc = finance.allocations[0]
+    model = AllocationModel.from_pydantic(alloc)
+
+    engine = create_engine("sqlite:///:memory:")
+    create_db_and_tables(engine)
+
+    with Session(engine) as session:
+        session.add(model)
+        session.commit()
+        result = session.exec(select(AllocationModel)).first()
+
+    assert result
+    assert result.uuid == alloc.uuid
+    assert result.user_id == alloc.user_id

--- a/wealth/wealth/__init__.py
+++ b/wealth/wealth/__init__.py
@@ -1,2 +1,12 @@
+from . import core, models, db
 from .core import *
 from .models import *
+from .schemas import load_schema, validate_finance
+from .db import *
+
+__all__ = (
+    core.__all__
+    + models.__all__
+    + ["load_schema", "validate_finance"]
+    + db.__all__
+)

--- a/wealth/wealth/db/__init__.py
+++ b/wealth/wealth/db/__init__.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import uuid4
+
+from sqlmodel import SQLModel, Field, create_engine, Session
+
+
+class WealthSQLModel(SQLModel):
+    """Base fields shared across models."""
+
+    uuid: str = Field(default_factory=lambda: str(uuid4()), primary_key=True)
+    user_id: str
+    name: str
+    description: Optional[str] = None
+    parent_id: Optional[str] = None
+    notes: Optional[str] = None
+    is_active: bool = True
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+class AllocationModel(WealthSQLModel, table=True):
+    __tablename__ = "allocations"
+
+    allocation_type: str
+    budget_amount: Optional[float] = None
+    budget_percentage: Optional[float] = None
+    savings_bucket: Optional[str] = None
+    risk_score: float = 0.0
+    risk_level: str = "low"
+    active: bool = True
+
+    @classmethod
+    def from_pydantic(cls, allocation: "Allocation") -> "AllocationModel":
+        return cls.model_validate(allocation.model_dump())
+
+
+class InvestmentModel(WealthSQLModel, table=True):
+    __tablename__ = "investments"
+
+    asset_type: str
+    amount_invested: float = 0.0
+    current_value: float = 0.0
+    platform: Optional[str] = None
+    risk_score: float = 0.0
+    risk_level: str = "medium"
+
+    @classmethod
+    def from_pydantic(cls, investment: "Investment") -> "InvestmentModel":
+        return cls.model_validate(investment.model_dump())
+
+
+def create_db_and_tables(engine):
+    """Create tables for all SQLModel models."""
+    SQLModel.metadata.create_all(engine)
+
+
+__all__ = [
+    "SQLModel",
+    "Session",
+    "create_engine",
+    "create_db_and_tables",
+    "AllocationModel",
+    "InvestmentModel",
+    "WealthSQLModel",
+]

--- a/wealth/wealth/schemas/__init__.py
+++ b/wealth/wealth/schemas/__init__.py
@@ -1,0 +1,27 @@
+import json
+from importlib.resources import files
+from typing import Any, Dict
+
+from jsonschema import validate
+from jsonschema.validators import Draft7Validator
+
+from wealth.core.finance import Finance
+
+
+SCHEMA_FILE = "wealth.schema.json"
+
+
+def load_schema() -> Dict[str, Any]:
+    """Load the bundled wealth JSON schema."""
+    path = files(__package__) / SCHEMA_FILE
+    return json.loads(path.read_text())
+
+
+def validate_finance(finance: Finance) -> None:
+    """Validate a ``Finance`` model against the JSON schema."""
+    schema = load_schema()
+    validate(
+        instance=finance.model_dump(),
+        schema=schema,
+        format_checker=Draft7Validator.FORMAT_CHECKER,
+    )

--- a/wealth/wealth/schemas/wealth.schema.json
+++ b/wealth/wealth/schemas/wealth.schema.json
@@ -1,0 +1,284 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Wealth Models",
+  "type": "object",
+  "definitions": {
+    "Wealth": {
+      "type": "object",
+      "properties": {
+        "uuid": {"type": "string"},
+        "user_id": {"type": "string"},
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "parent_id": {"type": "string"},
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "notes": {"type": "string"},
+        "is_active": {"type": "boolean"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "updated_at": {"type": "string", "format": "date-time"}
+      },
+      "required": ["uuid", "user_id", "name", "tags", "is_active", "created_at", "updated_at"]
+    },
+    "RiskType": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "speculative", "guaranteed"]
+    },
+    "RiskProfile": {
+      "type": "string",
+      "enum": ["conservative", "moderate", "balanced", "aggressive", "speculative"]
+    },
+    "Risk": {
+      "type": "object",
+      "properties": {
+        "uuid": {"type": "string"},
+        "name": {"type": "string"},
+        "score": {"type": "number"},
+        "level": {"$ref": "#/definitions/RiskType"},
+        "description": {"type": "string"},
+        "source_object_type": {"type": "string"},
+        "source_object_id": {"type": "string"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "updated_at": {"type": "string", "format": "date-time"}
+      },
+      "required": ["uuid", "name", "score", "level", "created_at", "updated_at"]
+    },
+    "Service": {
+      "type": "object",
+      "properties": {
+        "uuid": {"type": "string"},
+        "name": {"type": "string"},
+        "url": {"type": "string", "format": "uri"},
+        "logo_url": {"type": "string", "format": "uri"},
+        "provider": {"type": "string"},
+        "notes": {"type": "string"}
+      },
+      "required": ["uuid", "name"]
+    },
+    "AssetType": {
+      "type": "string",
+      "enum": [
+        "stock", "etf", "mutual_fund", "crypto", "reit", "bond", "option", "future",
+        "cash", "commodity", "collectible", "crowdfunding", "angel_investment",
+        "real_estate", "business_equity", "other"
+      ]
+    },
+    "Investment": {
+      "allOf": [
+        {"$ref": "#/definitions/Wealth"},
+        {
+          "type": "object",
+          "properties": {
+            "asset_type": {"$ref": "#/definitions/AssetType"},
+            "amount_invested": {"type": "number"},
+            "current_value": {"type": "number"},
+            "platform": {"type": "string"},
+            "risk_score": {"type": "number"},
+            "risk_level": {"$ref": "#/definitions/RiskType"},
+            "risk": {"$ref": "#/definitions/Risk"}
+          },
+          "required": ["asset_type", "amount_invested", "current_value", "risk_score", "risk_level"]
+        }
+      ]
+    },
+    "AllocationType": {
+      "type": "string",
+      "enum": ["fixed", "variable"]
+    },
+    "Allocation": {
+      "allOf": [
+        {"$ref": "#/definitions/Wealth"},
+        {
+          "type": "object",
+          "properties": {
+            "allocation_type": {"$ref": "#/definitions/AllocationType"},
+            "budget_amount": {"type": "number"},
+            "budget_percentage": {"type": "number"},
+            "savings_bucket": {"type": "string"},
+            "risk_score": {"type": "number"},
+            "risk_level": {"$ref": "#/definitions/RiskType"},
+            "risk": {"$ref": "#/definitions/Risk"},
+            "tags": {"type": "array", "items": {"type": "string"}},
+            "services": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/Service"}
+            },
+            "active": {"type": "boolean"}
+          },
+          "required": ["allocation_type", "risk_score", "risk_level", "tags", "services", "active"]
+        }
+      ]
+    },
+    "ExpenseCategory": {
+      "type": "string",
+      "enum": [
+        "housing", "utilities", "groceries", "transportation", "healthcare",
+        "insurance", "entertainment", "subscriptions", "education", "childcare",
+        "pets", "charity", "personal_care", "gifts", "business", "taxes", "loans",
+        "debt_repayment", "investment", "other"
+      ]
+    },
+    "ExpenseFrequency": {
+      "type": "string",
+      "enum": [
+        "one_time", "daily", "weekly", "biweekly", "semimonthly", "monthly",
+        "bimonthly", "quarterly", "semiannually", "annually", "irregular"
+      ]
+    },
+    "Expense": {
+      "allOf": [
+        {"$ref": "#/definitions/Wealth"},
+        {
+          "type": "object",
+          "properties": {
+            "amount": {"type": "number"},
+            "date": {"type": "string", "format": "date-time"},
+            "category": {"$ref": "#/definitions/ExpenseCategory"},
+            "frequency": {"$ref": "#/definitions/ExpenseFrequency"},
+            "source_account": {"type": "string"}
+          },
+          "required": ["amount", "date", "category", "frequency", "source_account"]
+        }
+      ]
+    },
+    "IncomeType": {
+      "type": "string",
+      "enum": [
+        "active", "passive", "freelance", "business", "investment", "rental",
+        "platform", "crypto", "royalty", "retirement", "social_security", "stipend",
+        "disability", "child_support", "alimony", "windfall", "other"
+      ]
+    },
+    "IncomeFrequency": {
+      "type": "string",
+      "enum": [
+        "one_time", "daily", "weekly", "biweekly", "semimonthly", "monthly",
+        "bimonthly", "quarterly", "semiannually", "annually", "irregular"
+      ]
+    },
+    "Income": {
+      "allOf": [
+        {"$ref": "#/definitions/Wealth"},
+        {
+          "type": "object",
+          "properties": {
+            "source": {"type": "string"},
+            "amount": {"type": "number"},
+            "frequency": {"$ref": "#/definitions/IncomeFrequency"},
+            "type": {"$ref": "#/definitions/IncomeType"}
+          },
+          "required": ["source", "amount", "frequency", "type"]
+        }
+      ]
+    },
+    "DebtType": {
+      "type": "string",
+      "enum": [
+        "credit_card", "personal_loan", "student_loan", "auto_loan", "mortgage",
+        "medical", "business_loan", "line_of_credit", "buy_now_pay_later", "other"
+      ]
+    },
+    "DebtStatus": {
+      "type": "string",
+      "enum": ["open", "closed", "defaulted", "deferred", "paid_off"]
+    },
+    "Debt": {
+      "allOf": [
+        {"$ref": "#/definitions/Wealth"},
+        {
+          "type": "object",
+          "properties": {
+            "debt_type": {"$ref": "#/definitions/DebtType"},
+            "status": {"$ref": "#/definitions/DebtStatus"},
+            "balance": {"type": "number"},
+            "apr": {"type": "number"},
+            "min_payment": {"type": "number"},
+            "snowball_priority": {"type": "number"},
+            "risk_score": {"type": "number"},
+            "risk_level": {"$ref": "#/definitions/RiskType"},
+            "risk": {"$ref": "#/definitions/Risk"},
+            "lender": {"type": "string"},
+            "account_number": {"type": "string"},
+            "due_day": {"type": "integer"},
+            "is_tax_deductible": {"type": "boolean"},
+            "auto_pay_enabled": {"type": "boolean"}
+          },
+          "required": [
+            "debt_type", "status", "balance", "apr", "min_payment", "risk_score",
+            "risk_level", "is_tax_deductible", "auto_pay_enabled"
+          ]
+        }
+      ]
+    },
+    "Portfolio": {
+      "allOf": [
+        {"$ref": "#/definitions/Wealth"},
+        {
+          "type": "object",
+          "properties": {
+            "investments": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/Investment"}
+            },
+            "risk_profile": {"$ref": "#/definitions/RiskProfile"},
+            "strategy_label": {"type": "string"}
+          },
+          "required": ["investments"]
+        }
+      ]
+    },
+    "LifecyclePhase": {
+      "type": "string",
+      "enum": [
+        "surviving", "stabilizing", "maintaining", "scaling", "thriving", "retiring"
+      ]
+    },
+    "Finance": {
+      "type": "object",
+      "properties": {
+        "user_id": {"type": "string"},
+        "allocations": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/Allocation"}
+        },
+        "expenses": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/Expense"}
+        },
+        "income_streams": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/Income"}
+        },
+        "debts": {"type": "array", "items": {"$ref": "#/definitions/Debt"}},
+        "investments": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/Investment"}
+        },
+        "portfolios": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/Portfolio"}
+        },
+        "services": {"type": "array", "items": {"$ref": "#/definitions/Service"}},
+        "roles": {"type": "array", "items": {"type": "string"}},
+        "features": {"type": "array", "items": {"type": "string"}},
+        "lifecycle_phase": {"$ref": "#/definitions/LifecyclePhase"},
+        "risk_profile": {"$ref": "#/definitions/RiskProfile"},
+        "notes": {"type": "string"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "updated_at": {"type": "string", "format": "date-time"}
+      },
+      "required": ["user_id", "allocations", "expenses", "income_streams", "debts",
+        "investments", "portfolios", "services", "roles", "features", "lifecycle_phase",
+        "created_at", "updated_at"]
+    },
+    "FinanceSummary": {
+      "type": "object",
+      "properties": {
+        "net_worth": {"type": "number"},
+        "investment_count": {"type": "integer"},
+        "debt_count": {"type": "integer"},
+        "allocation_count": {"type": "integer"}
+      },
+      "required": ["net_worth", "investment_count", "debt_count", "allocation_count"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- load wealth JSON schema inside the package and expose validation helpers
- add SQLModel-based persistence models
- export new helpers from package root
- bundle schema file for distribution
- include `sqlmodel` and `jsonschema` in package dependencies
- add tests for schema loading and SQLModel roundtrip

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_683ffb556830832cba669c84e4bf45c5