### PR TITLE
Update react-swc plugin version

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -32,7 +32,7 @@
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5",
     "vite": "^5.2.2",
-    "@vitejs/plugin-react-swc": "^4.2.0",
+    "@vitejs/plugin-react-swc": "^3.10.1",
     "vite-tsconfig-paths": "^4.2.0",
     "vite-plugin-checker": "^1.0.0",
     "vite-plugin-svgr": "^3.0.0",


### PR DESCRIPTION
## Summary
- set `@vitejs/plugin-react-swc` to the latest available `3.10.1` release

## Testing
- `pnpm install --no-frozen-lockfile` *(fails: GET https://registry.npmjs.org/@types%2Freact-router-dom: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_684110e89b10832cbc5506d89edc28b8