### PR TITLE
Fix pnpm install error in UI app

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -34,7 +34,7 @@
     "vite": "^5.2.2",
     "@vitejs/plugin-react-swc": "^3.10.1",
     "vite-tsconfig-paths": "^4.2.0",
-    "vite-plugin-checker": "^1.0.0",
+    "vite-plugin-checker": "^0.9.3",
     "vite-plugin-svgr": "^3.0.0",
     "vite-plugin-pwa": "^0.16.0",
     "@storybook/react-vite": "^8.0.0",


### PR DESCRIPTION
## Summary
- use existing `vite-plugin-checker` version

## Testing
- `pnpm install --no-frozen-lockfile` *(fails: GET https://registry.npmjs.org/@changesets%2Fcli 403)*
- `pnpm lint` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68411265b908832c9c7249782bb9de2c