### PR TITLE
Fix MegaLinter CLI option

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           node-version: '20'
       - name: Run MegaLinter
-        run: npx mega-linter-runner --path . --reporter markdown,html
+        run: npx mega-linter-runner --path .
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPORT_OUTPUT_FOLDER: reports/megalinter
+          REPORTERS: markdown,html


### PR DESCRIPTION
## Summary
- fix invalid MegaLinter option in workflow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841137c6004832c89b7cdbf612ffdbd