### PR TITLE
Fix UI dependency for React Keycloak

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.3",
-    "@react-keycloak/web": "^4.0.2",
+    "@react-keycloak/web": "^3.4.0",
     "keycloak-js": "^23.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary
- correct `@react-keycloak/web` version in `apps/ui` package

## Testing
- `pnpm install --no-frozen-lockfile` *(fails: GET https://registry.npmjs.org/autoprefixer: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_684114889b54832c8ca1313c43e7e197