### PR TITLE
Fix dependency for charting library

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -20,7 +20,7 @@
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.3",
     "react-router-dom": "^6.22.3",
-    "unovis": "^2.3.1",
+    "@unovis/ts": "^2.3.1",
     "react-oidc-context": "^1.4.1"
   },
   "devDependencies": {

--- a/apps/ui/src/components/Chart.tsx
+++ b/apps/ui/src/components/Chart.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { VisXYContainer, VisLine, VisAxis } from 'unovis'
+import { VisXYContainer, VisLine, VisAxis } from '@unovis/ts'
 
 export default function Chart() {
   const ref = useRef<HTMLDivElement>(null)


### PR DESCRIPTION
## Summary
- switch to `@unovis/ts` package in the UI app
- update import path in the chart component

## Testing
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68411596af9c832cadddfea2a7818bf9