### PR TITLE
Fix devtools feature

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
         "ghcr.io/devcontainers/features/nix:1": {
             "version": "latest",
             "multiUser": true,
-        "packages": "nodejs_20 pnpm python312Full poetry git pre-commit black nodePackages.prettier",
+        "packages": "nodejs_20 pnpm python312Full poetry git pre-commit black nodePackages.prettier go-task asdf-vm",
             "useAttributePath": true,
             "extraNixConfig": "experimental-features = nix-command flakes"
         },

--- a/.devcontainer/features/devtools/README.md
+++ b/.devcontainer/features/devtools/README.md
@@ -1,6 +1,6 @@
 # devtools
 
-Installs [asdf](https://asdf-vm.com/), the [Taskfile](https://taskfile.dev/#/) binary, and the [MegaLinter Runner](https://github.com/oxsecurity/megalinter) inside the dev container.
+Uses Nix packages [asdf-vm](https://asdf-vm.com/) and [go-task](https://taskfile.dev/#/) and installs the [MegaLinter Runner](https://github.com/oxsecurity/megalinter) inside the dev container.
 
 ## Example Usage
 
@@ -15,8 +15,8 @@ Installs [asdf](https://asdf-vm.com/), the [Taskfile](https://taskfile.dev/#/) b
 
 | Option Id | Description | Type | Default |
 |-----------|-------------|------|---------|
-| `asdf_version` | Version of asdf to install. | string | `latest` |
-| `taskfile_version` | Version of Taskfile binary to install. | string | `latest` |
+| `asdf_version` | **Ignored** - asdf is provided via Nix. | string | `latest` |
+| `taskfile_version` | **Ignored** - Taskfile is provided via Nix. | string | `latest` |
 
 ## OS Support
 

--- a/.devcontainer/features/devtools/devcontainer-feature.json
+++ b/.devcontainer/features/devtools/devcontainer-feature.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "name": "devtools",
     "documentationURL": "",
-    "description": "Installs devtools and MegaLinter Runner for the project.",
+    "description": "Verifies devtools and installs MegaLinter Runner for the project.",
     "options": {
         "asdf_version": {
             "type": "string",
@@ -32,12 +32,12 @@
         "ASDF_DATA_DIR": "/home/vscode/.asdf/data",
         "ASDF_SHIMS_DIR": "/home/vscode/.asdf/data/shims",
         // "ASDF_CONFIG_FILE": "/home/vscode/.asdf/asdfrc",
-        "TASKFILE_HOME_DIR": "/home/vscode/.taskfile",
-        "PATH": "/home/vscode/.asdf/data/shims:/home/vscode/.asdf/bin:/home/vscode/.taskfile:${PATH}"
+        "TASKFILE_HOME_DIR": "/home/vscode/.taskfile"
     },
     "mounts": [],
     "installsAfter": [
         "ghcr.io/devcontainers/features/common-utils",
-        "ghcr.io/devcontainers/features/docker-in-docker"
+        "ghcr.io/devcontainers/features/docker-in-docker",
+        "ghcr.io/devcontainers/features/nix"
     ]
 }

--- a/.devcontainer/features/devtools/install.sh
+++ b/.devcontainer/features/devtools/install.sh
@@ -1154,8 +1154,13 @@ asdf::verify() {
         local version
         version="$("$binary_path" --version 2>/dev/null || echo "Version info not available")"
         log::success "✅ ASDF installed at $binary_path: $version"
+    elif command -v asdf >/dev/null 2>&1; then
+        binary_path="$(command -v asdf)"
+        local version
+        version="$("$binary_path" --version 2>/dev/null || echo "Version info not available")"
+        log::success "✅ ASDF available at $binary_path: $version"
     else
-        log::error "❌ ASDF not found at $binary_path"
+        log::error "❌ ASDF not found"
         return 1
     fi
 }
@@ -1379,8 +1384,13 @@ taskfile::verify() {
         local version
         version="$("$binary_path" --version 2>/dev/null || "$binary_path" -v 2>/dev/null || echo "Version info not available")"
         log::success "✅ Taskfile installed at $binary_path: $version"
+    elif command -v task >/dev/null 2>&1; then
+        binary_path="$(command -v task)"
+        local version
+        version="$("$binary_path" --version 2>/dev/null || "$binary_path" -v 2>/dev/null || echo "Version info not available")"
+        log::success "✅ Taskfile available at $binary_path: $version"
     else
-        log::error "❌ Taskfile not found at $binary_path"
+        log::error "❌ Taskfile not found"
         return 1
     fi
 }
@@ -1453,9 +1463,9 @@ install::mega_linter() {
 # -----------------------------------------------------------------------------
 install() {
     log "🔧 Installing development tools..."
-    install::asdf
+    asdf::verify
     install_asdf_plugins
-    install::taskfile
+    taskfile::verify
     install::mega_linter
     log::success "🔧 Development tools installation complete."
 }

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ nix develop
 ```
 
 The dev container is configured to install Nix and use this flake, providing a
-consistent setup across machines. The devtools feature installs MegaLinter so
-you can run `task lint` directly inside the container.
+consistent setup across machines. The devtools feature verifies `asdf` and the
+`task` command from the Nix packages, then installs MegaLinter so you can run
+`task lint` directly inside the container.
 
 ## Pre-commit hooks
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,10 +23,12 @@
               pkgs.pre-commit
               pkgs.black
               pkgs.nodePackages.prettier
+              pkgs.go-task
+              pkgs.asdf-vm
             ];
 
           shellHook = ''
-            echo "✅ dev shell ready (Node, Python, Poetry, PNPM)"
+            echo "✅ dev shell ready (Node, Python, Poetry, PNPM, Taskfile, ASDF)"
           '';
         };
       });


### PR DESCRIPTION
## Summary
- manage Taskfile and asdf-vm via Nix
- verify asdf and task binaries instead of installing them
- add go-task and asdf-vm to Nix packages
- ensure devtools runs after the Nix feature
- document the new behaviour

## Testing
- `pre-commit run --files flake.nix .devcontainer/features/devtools/devcontainer-feature.json .devcontainer/features/devtools/install.sh .devcontainer/features/devtools/README.md .devcontainer/devcontainer.json README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b925b57c832ca1784bc90dcfe9df